### PR TITLE
Adding peer count

### DIFF
--- a/index.js
+++ b/index.js
@@ -13,13 +13,20 @@ app.use(function (state, emitter) {
   })
 
   emitter.on('broadcast:start', function (key) {
+    state.broadcast.peerCount = 0
     state.broadcast.active = true
     state.broadcast.key = key
 
     emitter.emit('render')
   })
 
+  emitter.on('broadcast:peer', function (peerCount) {
+    state.broadcast.peerCount = peerCount
+    emitter.emit('render')
+  })
+
   emitter.on('broadcast:stop', function (key) {
+    state.broadcast.peerCount = 0
     state.broadcast.active = false
     state.broadcast.key = null
 

--- a/lib/broadcast.js
+++ b/lib/broadcast.js
@@ -8,7 +8,8 @@ var cluster = require('webm-cluster-stream')
 exports.start = start
 exports.stop = stop
 
-function start (cb, audioOnly) {
+function start (startCallback, peerCallback, audioOnly) {
+
   var swarm, block = 0
   var mimeType = audioOnly ? 'audio/webm;codecs=opus' : 'video/webm;codecs=vp9,opus'
   var mediaRecorder = recorder(window.stream, {
@@ -24,7 +25,7 @@ function start (cb, audioOnly) {
   feed.on('ready', function () {
     swarm = hyperdiscovery(feed, {live: true})
     console.log(swarm);
-    cb(feed.key.toString('hex'))
+    startCallback(feed.key.toString('hex'))
 
     fs.readFile(`${__dirname}/viewer.html`, function (err, data) {
       if (err) console.log('error reading viewer.html', err)
@@ -54,6 +55,8 @@ function start (cb, audioOnly) {
       })
 
       console.log(`Streaming to ${swarm.connections.length} peers`)
+
+      peerCallback(swarm.connections.length)
 
       block++
     })

--- a/lib/broadcast.js
+++ b/lib/broadcast.js
@@ -23,6 +23,7 @@ function start (cb, audioOnly) {
 
   feed.on('ready', function () {
     swarm = hyperdiscovery(feed, {live: true})
+    console.log(swarm);
     cb(feed.key.toString('hex'))
 
     fs.readFile(`${__dirname}/viewer.html`, function (err, data) {
@@ -51,6 +52,8 @@ function start (cb, audioOnly) {
       feed.writeFile(block + '.buffer', data, function (err) {
         if (err) console.log('block write error', err)
       })
+
+      console.log(`Streaming to ${swarm.connections.length} peers`)
 
       block++
     })

--- a/lib/broadcast.js
+++ b/lib/broadcast.js
@@ -24,7 +24,6 @@ function start (startCallback, peerCallback, audioOnly) {
 
   feed.on('ready', function () {
     swarm = hyperdiscovery(feed, {live: true})
-    console.log(swarm);
     startCallback(feed.key.toString('hex'))
 
     fs.readFile(`${__dirname}/viewer.html`, function (err, data) {

--- a/templates/home.js
+++ b/templates/home.js
@@ -22,7 +22,7 @@ function home (state, emit) {
         <div id="nav">
           ${label({
             color: !state.broadcast.active ? 'grey' : 'red',
-            text: !state.broadcast.active ? 'Standby' : 'On Air'
+            text: !state.broadcast.active ? 'Standby' : `On Air: ${state.broadcast.peerCount} viewer(s)`
           })}
           <div id="actions">
             ${button({
@@ -79,6 +79,8 @@ function home (state, emit) {
   function startBroadcast () {
     broadcast.start(function (key) {
       emit('broadcast:start', key)
+    }, function(peerCount) {
+      emit('broadcast:peer', peerCount)
     }, state.broadcast.audioOnly)
   }
 


### PR DESCRIPTION
This add a peer count using `swarm.connection.length` and is updated per block. Could be used as metadata for timeline data of the stream.

Related issue on Hypervision: https://github.com/mafintosh/hypervision/issues/12 
